### PR TITLE
- Version 1.0.0-RC1.

### DIFF
--- a/AmbientContexts.Tests/AmbientScopeTests.Disposal.cs
+++ b/AmbientContexts.Tests/AmbientScopeTests.Disposal.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using Xunit;
+
+namespace Architect.AmbientContexts.Tests
+{
+	public sealed partial class AmbientScopeTests
+	{
+		[Fact]
+		public void SetDefaultScope_Regularly_ShouldNotMakeScopeAmbient()
+		{
+			using var scope = new StaticTestScope1();
+
+			StaticTestScope1.SetDefaultScope(scope);
+
+			Assert.NotEqual(StaticTestScope1.CurrentNondefault, scope);
+		}
+
+		private sealed class StaticTestScope1 : StaticTestScope<StaticTestScope1>
+		{
+		}
+
+		[Fact]
+		public void SetDefaultScope_Regularly_ShouldNotCallCustomDispose()
+		{
+			using var scope = new StaticTestScope2();
+
+			StaticTestScope2.SetDefaultScope(scope);
+
+			Assert.False(scope.IsCustomDisposed);
+		}
+
+		private sealed class StaticTestScope2 : StaticTestScope<StaticTestScope2>
+		{
+		}
+
+		[Fact]
+		public void SetDefaultScope_ReplacingPreviousScopeByNew_ShouldCallCustomDisposeOnPrevious()
+		{
+			using var previousScope = new StaticTestScope3();
+			StaticTestScope3.SetDefaultScope(previousScope);
+
+			using var newScope = new StaticTestScope3();
+			StaticTestScope3.SetDefaultScope(newScope);
+
+			Assert.True(previousScope.IsCustomDisposed);
+		}
+
+		private sealed class StaticTestScope3 : StaticTestScope<StaticTestScope3>
+		{
+		}
+
+		[Fact]
+		public void SetDefaultScope_ReplacingPreviousScopeByNull_ShouldCallCustomDisposeOnPrevious()
+		{
+			using var previousScope = new StaticTestScope4();
+			StaticTestScope4.SetDefaultScope(previousScope);
+
+			StaticTestScope4.SetDefaultScope(null);
+
+			Assert.True(previousScope.IsCustomDisposed);
+		}
+
+		private sealed class StaticTestScope4 : StaticTestScope<StaticTestScope4>
+		{
+		}
+
+		[Fact]
+		public void SetDefaultScope_WithJoinExistingOption_ShouldThrow()
+		{
+			using var scope = new StaticTestScope5();
+
+			Assert.ThrowsAny<ArgumentException>(() =>
+				StaticTestScope5.SetDefaultScope(scope));
+		}
+
+		private sealed class StaticTestScope5 : StaticTestScope<StaticTestScope5>
+		{
+			public StaticTestScope5()
+				: base(AmbientScopeOption.JoinExisting)
+			{
+			}
+		}
+
+		[Fact]
+		public void SetDefaultScope_WithException_ShouldLeaveExistingDefaultScope()
+		{
+			using var previousScope = new StaticTestScope6(throwsWhenMadeDefault: false);
+			StaticTestScope6.SetDefaultScope(previousScope);
+
+			using var newScope = new StaticTestScope6(throwsWhenMadeDefault: true);
+			Assert.ThrowsAny<ArgumentException>(() =>
+				StaticTestScope6.SetDefaultScope(newScope));
+
+			Assert.Equal(previousScope, StaticTestScope6.Current);
+		}
+
+		private sealed class StaticTestScope6 : StaticTestScope<StaticTestScope6>
+		{
+			public StaticTestScope6(bool throwsWhenMadeDefault)
+				: base(throwsWhenMadeDefault ? AmbientScopeOption.JoinExisting : AmbientScopeOption.NoNesting)
+			{
+			}
+		}
+
+		[Fact]
+		public void Dispose_WhileTheDefaultScope_ShouldUnsetDefaultScope()
+		{
+			using (var scope = new StaticTestScope7())
+			{
+				StaticTestScope7.SetDefaultScope(scope);
+			}
+
+			Assert.Null(StaticTestScope7.Current);
+		}
+
+		private sealed class StaticTestScope7 : StaticTestScope<StaticTestScope7>
+		{
+		}
+
+		[Fact]
+		public void Dispose_WhileNoLongerTheDefaultScope_ShouldNotTouchDefaultScope()
+		{
+			using var newDefaultScope = new StaticTestScope8();
+
+			using (var previousDefaultScope = new StaticTestScope8())
+			{
+				StaticTestScope8.SetDefaultScope(previousDefaultScope);
+				StaticTestScope8.SetDefaultScope(newDefaultScope);
+			}
+
+			Assert.Equal(newDefaultScope, StaticTestScope8.Current);
+		}
+
+		private sealed class StaticTestScope8 : StaticTestScope<StaticTestScope8>
+		{
+		}
+	}
+}

--- a/AmbientContexts.Tests/AmbientScopeTests.HelperClasses.cs
+++ b/AmbientContexts.Tests/AmbientScopeTests.HelperClasses.cs
@@ -1,0 +1,120 @@
+﻿using System;
+
+namespace Architect.AmbientContexts.Tests
+{
+	public sealed partial class AmbientScopeTests
+	{
+		private sealed class TestScope : AmbientScope<TestScope>
+		{
+			public const int DefaultIndex = -1;
+			public static readonly TestScope DefaultScopeConstant = new TestScope(DefaultIndex, AmbientScopeOption.NoNesting, activate: false);
+
+			static TestScope()
+			{
+				SetDefaultScope(DefaultScopeConstant);
+			}
+
+			public int Index { get; }
+			public int ParentIndex => Current.EffectiveParentScope.Index;
+
+			public new TestScope PhysicalParentScope => base.PhysicalParentScope;
+			public new TestScope EffectiveParentScope => base.EffectiveParentScope;
+			public new TestScope GetEffectiveRootScope() => base.GetEffectiveRootScope();
+
+			public TestScope(int index, AmbientScopeOption scopeOption, bool activate = true)
+				: base(scopeOption)
+			{
+				this.Index = index;
+
+				if (activate) this.Activate();
+			}
+
+			protected override void DisposeImplementation()
+			{
+			}
+
+			public static TestScope Current => GetAmbientScope();
+			public static TestScope CurrentNondefault => GetAmbientScope(considerDefaultScope: false);
+		}
+
+		private class ManuallyActivatedScope : AmbientScope<ManuallyActivatedScope>
+		{
+			public const int DefaultIndex = -1;
+
+			static ManuallyActivatedScope()
+			{
+				SetDefaultScope(new ManuallyActivatedScope(DefaultIndex, AmbientScopeOption.NoNesting));
+			}
+
+			public int Index { get; }
+			public int ParentIndex => Current.EffectiveParentScope.Index;
+			protected override bool NoNestingIgnoresDefaultScope { get; }
+			
+			public new ManuallyActivatedScope PhysicalParentScope => base.PhysicalParentScope;
+			public new ManuallyActivatedScope EffectiveParentScope => base.EffectiveParentScope;
+			public new ManuallyActivatedScope GetEffectiveRootScope() => base.GetEffectiveRootScope();
+
+			public ManuallyActivatedScope(int index, AmbientScopeOption scopeOption, bool noNestingIgnoresDefaultScope = false)
+				: base(scopeOption)
+			{
+				this.Index = index;
+				this.NoNestingIgnoresDefaultScope = noNestingIgnoresDefaultScope;
+			}
+
+			protected override void DisposeImplementation()
+			{
+			}
+
+			public new void Activate() => base.Activate();
+
+			public static ManuallyActivatedScope Current => GetAmbientScope();
+			public static ManuallyActivatedScope CurrentNondefault => GetAmbientScope(considerDefaultScope: false);
+		}
+
+		/// <summary>
+		/// Because we want to test some static behaviors, we will need various copies of a class like this.
+		/// By subclassing, most of the code need not be duplicated.
+		/// </summary>
+		private abstract class StaticTestScope<TSelf> : AmbientScope<TSelf>
+			where TSelf : StaticTestScope<TSelf>
+		{
+			public static TSelf Current => GetAmbientScope();
+			public static TSelf CurrentNondefault => GetAmbientScope(considerDefaultScope: false);
+
+			public int Index { get; private set; }
+
+			public bool IsCustomDisposed { get; private set; }
+
+			protected override bool NoNestingIgnoresDefaultScope => true;
+
+			public StaticTestScope()
+				: this(AmbientScopeOption.NoNesting)
+			{
+			}
+
+			public StaticTestScope(AmbientScopeOption option)
+				: base(option)
+			{
+				this.Index = -1;
+			}
+
+			protected override void DisposeImplementation()
+			{
+				this.IsCustomDisposed = true;
+			}
+
+			public static void SetDefaultScope(int index)
+			{
+				var instance = Activator.CreateInstance<TSelf>();
+				instance.Index = index;
+
+				SetDefaultScope(instance);
+			}
+
+			public static new void SetDefaultScope(TSelf instance)
+			{
+				AmbientScope<TSelf>.SetDefaultScope(instance);
+			}
+		}
+	}
+}

--- a/AmbientContexts.Tests/AmbientScopeTests.Parallelism.cs
+++ b/AmbientContexts.Tests/AmbientScopeTests.Parallelism.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Architect.AmbientContexts.Tests
+{
+	public sealed partial class AmbientScopeTests
+	{
+		[Fact]
+		public void Current_FromParallel_ShouldSeeDefault()
+		{
+			Parallel.For(0, 100, index =>
+			{
+				Assert.Equal(TestScope.DefaultIndex, TestScope.Current.Index);
+			});
+		}
+
+		[Fact]
+		public void Construct_FromParallel_ShouldNotSeeEachOther()
+		{
+			using (new TestScope(Int32.MaxValue, AmbientScopeOption.ForceCreateNew))
+			{
+				Parallel.For(0, 2, index =>
+				{
+					if (index != 0) Thread.Sleep(20);
+
+					Assert.Equal(Int32.MaxValue, TestScope.Current.Index); // Should see the outer scope
+
+					using (new TestScope(index, AmbientScopeOption.JoinExisting))
+					{
+						Assert.Equal(index, TestScope.Current.Index); // Should see the own scope
+						Assert.Equal(Int32.MaxValue, TestScope.Current.ParentIndex); // Should have the outer scope as the effective parent
+						Thread.Sleep(60);
+					}
+				});
+			}
+		}
+
+		[Fact]
+		public void Construct_FromParallel_ShouldNotInterfereWithEachOther()
+		{
+			Parallel.For(0, 100, index =>
+			{
+				using (new TestScope(index, AmbientScopeOption.ForceCreateNew))
+				{
+					Assert.Equal(index, TestScope.Current.Index);
+				}
+			});
+		}
+
+		[Fact]
+		public void Construct_FromParallelWithJoinExisting_ShouldSeeDefaultParent()
+		{
+			Parallel.For(0, 100, index =>
+			{
+				using (new TestScope(index, AmbientScopeOption.JoinExisting))
+				{
+					Assert.Equal(TestScope.DefaultIndex, TestScope.Current.ParentIndex);
+				}
+			});
+		}
+
+		[Fact]
+		public void Construct_FromParallelWithJoinExistingAndOuterScope_ShouldSeeOuterScopeParent()
+		{
+			using (new TestScope(Int32.MaxValue, AmbientScopeOption.ForceCreateNew))
+			{
+				Parallel.For(0, 100, index =>
+				{
+					using (new TestScope(index, AmbientScopeOption.JoinExisting))
+					{
+						Assert.Equal(Int32.MaxValue, TestScope.Current.ParentIndex);
+					}
+				});
+			}
+		}
+
+		[Fact]
+		public void Construct_FromParallelWithForceCreateNewAndOuterScope_ShouldNotInterfereWithEachOther()
+		{
+			using (new TestScope(Int32.MaxValue, AmbientScopeOption.ForceCreateNew))
+			{
+				Parallel.For(0, 100, index =>
+				{
+					using (new TestScope(index, AmbientScopeOption.ForceCreateNew))
+					{
+						Assert.Equal(index, TestScope.Current.Index);
+					}
+				});
+			}
+		}
+	}
+}

--- a/AmbientContexts.Tests/AmbientScopeTests.State.cs
+++ b/AmbientContexts.Tests/AmbientScopeTests.State.cs
@@ -1,0 +1,63 @@
+﻿using Xunit;
+
+namespace Architect.AmbientContexts.Tests
+{
+	public sealed partial class AmbientScopeTests
+	{
+		[Fact]
+		public void Construct_Regularly_ShouldResultInStateNew()
+		{
+			using var scope = new ManuallyActivatedScope(1, AmbientScopeOption.ForceCreateNew);
+			Assert.Equal(AmbientScopeState.New, scope.State);
+		}
+		
+		[Fact]
+		public void Activate_Regularly_ShouldResultInStateActive()
+		{
+			using var scope = new ManuallyActivatedScope(1, AmbientScopeOption.ForceCreateNew);
+
+			scope.Activate();
+
+			Assert.Equal(AmbientScopeState.Active, scope.State);
+		}
+		
+		[Fact]
+		public void Construct_WithActivateFromConstructor_ShouldResultInStateActive()
+		{
+			using var scope = new TestScope(1, AmbientScopeOption.ForceCreateNew);
+
+			Assert.Equal(AmbientScopeState.Active, scope.State);
+		}
+		
+		[Fact]
+		public void Dispose_FromStateNew_ShouldResultInStateDisposed()
+		{
+			using var scope = new ManuallyActivatedScope(1, AmbientScopeOption.ForceCreateNew);
+
+			scope.Dispose();
+
+			Assert.Equal(AmbientScopeState.Disposed, scope.State);
+		}
+		
+		[Fact]
+		public void Dispose_FromStateActive_ShouldResultInStateDisposed()
+		{
+			using var scope = new TestScope(1, AmbientScopeOption.ForceCreateNew);
+
+			scope.Dispose();
+
+			Assert.Equal(AmbientScopeState.Disposed, scope.State);
+		}
+		
+		[Fact]
+		public void Dispose_TwiceFromStateActive_ShouldResultInStateDisposed()
+		{
+			using var scope = new TestScope(1, AmbientScopeOption.ForceCreateNew);
+
+			scope.Dispose();
+			scope.Dispose();
+
+			Assert.Equal(AmbientScopeState.Disposed, scope.State);
+		}
+	}
+}

--- a/AmbientContexts.Tests/AmbientScopeTests.cs
+++ b/AmbientContexts.Tests/AmbientScopeTests.cs
@@ -1,119 +1,280 @@
 ﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Architect.AmbientContexts.Tests
 {
-	public class AmbientScopeTests
+	public sealed partial class AmbientScopeTests
 	{
 		[Fact]
-		public void Current_FromParallel_ShouldSeeDefault()
+		public void Construct_Regularly_ShouldNotRegisterAmbientScope()
 		{
-			Parallel.For(0, 100, index =>
-			{
-				Assert.Equal(TestScope.DefaultIndex, TestScope.Current.Index);
-			});
+			using var scope = new ManuallyActivatedScope(1, AmbientScopeOption.NoNesting);
+			Assert.Null(ManuallyActivatedScope.CurrentNondefault);
 		}
 
 		[Fact]
-		public void Construct_FromParallel_ShouldNotSeeEachOther()
+		public void Activate_Regularly_ShouldRegisterAmbientScope()
 		{
-			using (new TestScope(Int32.MaxValue, AmbientScopeOption.ForceCreateNew))
-			{
-				Parallel.For(0, 2, index =>
-				{
-					if (index != 0) Thread.Sleep(20);
+			using var scope = new ManuallyActivatedScope(1, AmbientScopeOption.NoNesting, noNestingIgnoresDefaultScope: true);
+			scope.Activate();
 
-					Assert.Equal(Int32.MaxValue, TestScope.Current.Index); // Should see the outer scope
-
-					using (new TestScope(index, AmbientScopeOption.JoinExisting))
-					{
-						Assert.Equal(index, TestScope.Current.Index); // Should see the own scope
-						Assert.Equal(Int32.MaxValue, TestScope.Current.ParentIndex); // Should have the outer scope as the effective parent
-						Thread.Sleep(60);
-					}
-				});
-			}
+			Assert.Equal(scope, ManuallyActivatedScope.CurrentNondefault);
 		}
 
 		[Fact]
-		public void Construct_FromParallel_ShouldNotInterfereWithEachOther()
+		public void Activate_Twice_ShouldThrow()
 		{
-			Parallel.For(0, 100, index =>
-			{
-				using (new TestScope(index, AmbientScopeOption.ForceCreateNew))
-				{
-					Assert.Equal(index, TestScope.Current.Index);
-				}
-			});
+			using var scope = new ManuallyActivatedScope(1, AmbientScopeOption.NoNesting, noNestingIgnoresDefaultScope: true);
+			scope.Activate();
+
+			Assert.ThrowsAny<InvalidOperationException>(() => scope.Activate());
 		}
 
 		[Fact]
-		public void Construct_FromParallelWithJoinExisting_ShouldSeeDefaultParent()
+		public void Activate_AfterDisposal_ShouldThrow()
 		{
-			Parallel.For(0, 100, index =>
-			{
-				using (new TestScope(index, AmbientScopeOption.JoinExisting))
-				{
-					Assert.Equal(TestScope.DefaultIndex, TestScope.Current.ParentIndex);
-				}
-			});
+			using var scope = new ManuallyActivatedScope(1, AmbientScopeOption.NoNesting, noNestingIgnoresDefaultScope: true);
+			scope.Dispose();
+
+			Assert.ThrowsAny<InvalidOperationException>(() => scope.Activate());
 		}
 
 		[Fact]
-		public void Construct_FromParallelWithJoinExistingAndOuterScope_ShouldSeeOuterScopeParent()
+		public void Activate_Default_ShouldThrow()
 		{
-			using (new TestScope(Int32.MaxValue, AmbientScopeOption.ForceCreateNew))
-			{
-				Parallel.For(0, 100, index =>
-				{
-					using (new TestScope(index, AmbientScopeOption.JoinExisting))
-					{
-						Assert.Equal(Int32.MaxValue, TestScope.Current.ParentIndex);
-					}
-				});
-			}
+			Assert.ThrowsAny<InvalidOperationException>(() => ManuallyActivatedScope.Current.Activate());
 		}
 
 		[Fact]
-		public void Construct_FromParallelWithForceCreateNewAndOuterScope_ShouldNotInterfereWithEachOther()
+		public void Activate_WithNoNestingAndIgnoredDefaultScope_ShouldSucceed()
 		{
-			using (new TestScope(Int32.MaxValue, AmbientScopeOption.ForceCreateNew))
-			{
-				Parallel.For(0, 100, index =>
-				{
-					using (new TestScope(index, AmbientScopeOption.ForceCreateNew))
-					{
-						Assert.Equal(index, TestScope.Current.Index);
-					}
-				});
-			}
+			using var scope = new ManuallyActivatedScope(1, AmbientScopeOption.NoNesting, noNestingIgnoresDefaultScope: true);
+			scope.Activate();
 		}
 
-		private class TestScope : AmbientScope<TestScope>
+		[Fact]
+		public void Activate_WithNoNestingAndDefaultScope_ShouldThrow()
 		{
-			public const int DefaultIndex = -1;
+			using var scope = new ManuallyActivatedScope(1, AmbientScopeOption.NoNesting);
+			Assert.ThrowsAny<InvalidOperationException>(() => scope.Activate());
+		}
 
-			static TestScope()
-			{
-				DefaultScope = new TestScope(DefaultIndex, AmbientScopeOption.NoNesting);
-			}
+		[Fact]
+		public void Activate_WithForceCreateNewAndDefaultScope_ShouldSucceed()
+		{
+			using var scope = new ManuallyActivatedScope(1, AmbientScopeOption.ForceCreateNew);
+			scope.Activate();
+		}
 
-			public int Index { get; }
-			public int ParentIndex => Current.EffectiveParentScope.Index;
+		[Fact]
+		public void Activate_WithJoinExistingAndDefaultScope_ShouldSucceed()
+		{
+			using var scope = new ManuallyActivatedScope(1, AmbientScopeOption.JoinExisting);
+			scope.Activate();
+		}
 
-			public TestScope(int index, AmbientScopeOption scopeOption)
-				: base(scopeOption)
-			{
-				this.Index = index;
-			}
+		[Fact]
+		public void Dispose_FromActiveWithUnderlyingScope_ShouldRevealExpectedScope()
+		{
+			using var scope1 = new TestScope(1, AmbientScopeOption.JoinExisting);
+			using var scope2 = new TestScope(1, AmbientScopeOption.JoinExisting);
+			scope2.Dispose();
 
-			protected override void DisposeImplementation()
-			{
-			}
+			Assert.Equal(scope1, TestScope.Current);
+		}
 
-			public static TestScope Current => (TestScope)GetAmbientScope();
+		[Fact]
+		public void Dispose_FromActiveWithDefaultScope_ShouldRevealExpectedScope()
+		{
+			using var scope = new TestScope(1, AmbientScopeOption.JoinExisting);
+			scope.Dispose();
+
+			Assert.Equal(TestScope.DefaultScopeConstant, TestScope.Current);
+		}
+
+		[Fact]
+		public void PhysicalParentScope_WithNoNesting_ShouldReturnNull()
+		{
+			using var scope = new ManuallyActivatedScope(1, AmbientScopeOption.NoNesting, noNestingIgnoresDefaultScope: true);
+			scope.Activate();
+
+			var parent = scope.PhysicalParentScope;
+
+			Assert.Null(parent);
+		}
+
+		[Fact]
+		public void EffectiveParentScope_WithNoNesting_ShouldReturnNull()
+		{
+			using var scope = new ManuallyActivatedScope(1, AmbientScopeOption.NoNesting, noNestingIgnoresDefaultScope: true);
+			scope.Activate();
+
+			var parent = scope.EffectiveParentScope;
+
+			Assert.Null(parent);
+		}
+
+		[Fact]
+		public void PhysicalParentScope_WithForceCreateNewAndDefault_ShouldReturnNull()
+		{
+			using var scope = new TestScope(1, AmbientScopeOption.ForceCreateNew);
+
+			var parent = scope.PhysicalParentScope;
+
+			Assert.Null(parent);
+		}
+
+		[Fact]
+		public void EffectiveParentScope_WithForceCreateNewAndDefault_ShouldReturnNull()
+		{
+			using var scope = new TestScope(1, AmbientScopeOption.ForceCreateNew);
+
+			var parent = scope.EffectiveParentScope;
+
+			Assert.Null(parent);
+		}
+
+		[Fact]
+		public void PhysicalParentScope_WithForceCreateNewAndUnderlyingScope_ShouldReturnUnderlyingScope()
+		{
+			using var underlyingScope = new TestScope(1, AmbientScopeOption.ForceCreateNew);
+			using var scope = new TestScope(1, AmbientScopeOption.ForceCreateNew);
+
+			var parent = scope.PhysicalParentScope;
+
+			Assert.Equal(underlyingScope, parent);
+		}
+
+		[Fact]
+		public void EffectiveParentScope_WithForceCreateNewAndUnderlyingScope_ShouldReturnNull()
+		{
+			using var underlyingScope = new TestScope(1, AmbientScopeOption.ForceCreateNew);
+			using var scope = new TestScope(1, AmbientScopeOption.ForceCreateNew);
+
+			var parent = scope.EffectiveParentScope;
+
+			Assert.Null(parent);
+		}
+
+		[Fact]
+		public void PhysicalParentScope_WithJoinExistingAndDefault_ShouldReturnNull()
+		{
+			using var scope = new TestScope(1, AmbientScopeOption.JoinExisting);
+
+			var parent = scope.PhysicalParentScope;
+
+			Assert.Null(parent);
+		}
+
+		[Fact]
+		public void EffectiveParentScope_WithJoinExistingAndDefault_ShouldReturnDefault()
+		{
+			using var scope = new TestScope(1, AmbientScopeOption.JoinExisting);
+
+			var parent = scope.EffectiveParentScope;
+
+			Assert.Equal(TestScope.DefaultScopeConstant, parent);
+		}
+
+		[Fact]
+		public void PhysicalParentScope_WithJoinExistingAndUnderlyingScope_ShouldReturnUnderlyingScope()
+		{
+			using var underlyingScope = new TestScope(1, AmbientScopeOption.JoinExisting);
+			using var scope = new TestScope(1, AmbientScopeOption.JoinExisting);
+
+			var parent = scope.PhysicalParentScope;
+
+			Assert.Equal(underlyingScope, parent);
+		}
+
+		[Fact]
+		public void EffectiveParentScope_WithJoinExistingAndUnderlyingScope_ShouldReturnUnderlyingScope()
+		{
+			using var underlyingScope = new TestScope(1, AmbientScopeOption.JoinExisting);
+			using var scope = new TestScope(1, AmbientScopeOption.JoinExisting);
+
+			var parent = scope.EffectiveParentScope;
+
+			Assert.Equal(underlyingScope, parent);
+		}
+
+		[Fact]
+		public void GetEffectiveRootScope_WithNoNesting_ShouldReturnSelf()
+		{
+			using var scope = new ManuallyActivatedScope(1, AmbientScopeOption.NoNesting, noNestingIgnoresDefaultScope: true);
+			scope.Activate();
+
+			var parent = scope.GetEffectiveRootScope();
+
+			Assert.Equal(scope, parent);
+		}
+
+		[Fact]
+		public void GetEffectiveRootScope_WithForceCreateNewAndDefault_ShouldReturnSelf()
+		{
+			using var scope = new TestScope(1, AmbientScopeOption.ForceCreateNew);
+
+			var parent = scope.GetEffectiveRootScope();
+
+			Assert.Equal(scope, parent);
+		}
+
+		[Fact]
+		public void GetEffectiveRootScope_WithForceCreateNewAndTransparentUnderlyingScope_ShouldReturnSelf()
+		{
+			using var underlyingScope = new TestScope(1, AmbientScopeOption.JoinExisting);
+			using var scope = new TestScope(1, AmbientScopeOption.ForceCreateNew);
+
+			var parent = scope.GetEffectiveRootScope();
+
+			Assert.Equal(scope, parent);
+		}
+
+		[Fact]
+		public void GetEffectiveRootScope_WithJoinExistingAndDefault_ShouldReturnDefault()
+		{
+			using var scope = new TestScope(1, AmbientScopeOption.JoinExisting);
+
+			var parent = scope.GetEffectiveRootScope();
+
+			Assert.Equal(TestScope.DefaultScopeConstant, parent);
+		}
+
+		[Fact]
+		public void GetEffectiveRootScope_WithJoinExistingAndOpaqueUnderlyingScope_ShouldReturnUnderlyingScope()
+		{
+			using var underlyingScope = new TestScope(1, AmbientScopeOption.ForceCreateNew);
+			using var scope = new TestScope(1, AmbientScopeOption.JoinExisting);
+
+			var parent = scope.GetEffectiveRootScope();
+
+			Assert.Equal(underlyingScope, parent);
+		}
+
+		[Fact]
+		public void GetEffectiveRootScope_WithJoinExistingAndTransparentUnderlyingScope_ShouldReturnDefault()
+		{
+			using var underlyingScope = new TestScope(1, AmbientScopeOption.JoinExisting);
+			using var scope = new TestScope(1, AmbientScopeOption.JoinExisting);
+
+			var parent = scope.GetEffectiveRootScope();
+
+			Assert.Equal(TestScope.DefaultScopeConstant, parent);
+		}
+
+		[Fact]
+		public void GetEffectiveRootScope_WithJoinExistingAndNoNestingUnderlyingScope_ShouldReturnUnderlyingScope()
+		{
+			using var underlyingScope = new ManuallyActivatedScope(1, AmbientScopeOption.NoNesting, noNestingIgnoresDefaultScope: true);
+			underlyingScope.Activate();
+
+			using var scope = new ManuallyActivatedScope(1, AmbientScopeOption.JoinExisting);
+			scope.Activate();
+
+			var parent = scope.GetEffectiveRootScope();
+
+			Assert.Equal(underlyingScope, parent);
 		}
 	}
 }
+

--- a/AmbientContexts/AmbientContexts.csproj
+++ b/AmbientContexts/AmbientContexts.csproj
@@ -1,21 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>Architect.AmbientContexts</AssemblyName>
     <RootNamespace>Architect.AmbientContexts</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup>
     <!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
-    <NoWarn>1573</NoWarn>
+    <!-- NoWarn: 1591=MissingXmlComments -->
+    <NoWarn>1573;1591</NoWarn>
     <LangVersion>latest</LangVersion>
-    <!--<Nullable>Enable</Nullable>-->
+    <Nullable>Enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.0.1</Version>
+    <Version>1.0.0-RC1</Version>
     <ReleaseNotes></ReleaseNotes>
     <Description>
 Provides the basis for implementing the Ambient Context pattern.

--- a/AmbientContexts/AmbientScope.State.cs
+++ b/AmbientContexts/AmbientScope.State.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading;
+
+namespace Architect.AmbientContexts
+{
+	public abstract partial class AmbientScope<TConcreteScope>
+	{
+		internal AmbientScopeState State => (AmbientScopeState)this._state;
+		private int _state = (int)AmbientScopeState.New;
+
+		private void ChangeState(AmbientScopeState newState)
+		{
+			this._state = (int)newState;
+		}
+
+		private void ChangeState(AmbientScopeState newState, out AmbientScopeState previousState)
+		{
+			previousState = (AmbientScopeState)Interlocked.Exchange(ref this._state, (int)newState);
+		}
+	}
+}

--- a/AmbientContexts/AmbientScopeState.cs
+++ b/AmbientContexts/AmbientScopeState.cs
@@ -1,0 +1,10 @@
+﻿namespace Architect.AmbientContexts
+{
+	internal enum AmbientScopeState
+	{
+		Default = -1,
+		New = 0,
+		Active = 1,
+		Disposed = 9,
+	}
+}

--- a/AmbientContexts/InternalsVisibleTo.cs
+++ b/AmbientContexts/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("Architect.AmbientContexts.Tests")]


### PR DESCRIPTION
- Major rework, for correctness. (Primarily protected against throwing from subclass constructor.)
- Activate() must now be called to activate a non-default instance.
- Now netcoreapp3.1 (instead of netstandard2.0) in order to Enable Nullable. (Could use netcoreapp2.1 or netstandard2.1, theoretically.)