### PR TITLE
Fix/1.1.1: disposal from deeper async level.

### DIFF
--- a/AmbientContexts.Example/AmbientContexts.Example.csproj
+++ b/AmbientContexts.Example/AmbientContexts.Example.csproj
@@ -8,6 +8,13 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
+    <!-- NoWarn: 1591=MissingXmlComments -->
+    <NoWarn>1573;1591</NoWarn>
+    <LangVersion>9</LangVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\AmbientContexts\AmbientContexts.csproj" />
   </ItemGroup>

--- a/AmbientContexts.Example/CapitalizedConsoleLogger.cs
+++ b/AmbientContexts.Example/CapitalizedConsoleLogger.cs
@@ -12,7 +12,7 @@ namespace Architect.AmbientContexts.Example
 		public void WriteEntry(string message, string submessage = null)
 		{
 			Console.WriteLine(message?.ToUpperInvariant());
-			if (submessage != null)
+			if (submessage is not null)
 			{
 				Console.Write('\t');
 				Console.WriteLine(submessage.ToUpperInvariant());

--- a/AmbientContexts.Example/ConsoleLogger.cs
+++ b/AmbientContexts.Example/ConsoleLogger.cs
@@ -12,7 +12,7 @@ namespace Architect.AmbientContexts.Example
 		public void WriteEntry(string message, string submessage = null)
 		{
 			Console.WriteLine(message);
-			if (submessage != null)
+			if (submessage is not null)
 			{
 				Console.Write('\t');
 				Console.WriteLine(submessage);

--- a/AmbientContexts.Example/LogScope.cs
+++ b/AmbientContexts.Example/LogScope.cs
@@ -38,7 +38,7 @@ namespace Architect.AmbientContexts.Example
 			var loggerList = loggers.ToList();
 
 			// If we are joining the existing scope (rather than obscuring it) and there is one, insert the existing loggers before our own
-			if (scopeOption == AmbientScopeOption.JoinExisting && GetAmbientScope() != null)
+			if (scopeOption == AmbientScopeOption.JoinExisting && GetAmbientScope() is not null)
 				loggerList.InsertRange(0, GetAmbientScope().Loggers);
 
 			this.Loggers = loggerList;

--- a/AmbientContexts.Tests/AmbientContexts.Tests.csproj
+++ b/AmbientContexts.Tests/AmbientContexts.Tests.csproj
@@ -7,6 +7,13 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
+    <!-- NoWarn: 1591=MissingXmlComments -->
+    <NoWarn>1573;1591</NoWarn>
+    <LangVersion>9</LangVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.7" />

--- a/AmbientContexts.Tests/AmbientScopeTests.Disposal.cs
+++ b/AmbientContexts.Tests/AmbientScopeTests.Disposal.cs
@@ -138,7 +138,7 @@ namespace Architect.AmbientContexts.Tests
 
 		/// <summary>
 		/// This tests a former issue caused by the fact that AsyncLocal changes are NOT observable further up the call stack than the nearest async method (which may be the method making the change).
-		/// A layer of indirection was added to tackle this issue.
+		/// To counteract the effect, the method that retrieves the current <see cref="AmbientScope"/> now navigates up through disposed scopes.
 		/// </summary>
 		[Fact]
 		public async Task Dispose_FromDeeperAsyncMethod_ShouldHaveEffectObservableInCaller()

--- a/AmbientContexts.Tests/AmbientScopeTests.Disposal.cs
+++ b/AmbientContexts.Tests/AmbientScopeTests.Disposal.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Architect.AmbientContexts.Tests
@@ -133,6 +134,47 @@ namespace Architect.AmbientContexts.Tests
 
 		private sealed class StaticTestScope8 : StaticTestScope<StaticTestScope8>
 		{
+		}
+
+		/// <summary>
+		/// This tests a former issue caused by the fact that AsyncLocal changes are NOT observable further up the call stack than the nearest async method (which may be the method making the change).
+		/// A layer of indirection was added to tackle this issue.
+		/// </summary>
+		[Fact]
+		public async Task Dispose_FromDeeperAsyncMethod_ShouldHaveEffectObservableInCaller()
+		{
+			new StaticTestScope9(value: 1);
+			var innerScope = new StaticTestScope9(value: 2);
+
+			Assert.Equal(2, StaticTestScope9.Current.Value);
+
+			await DisposeInnerScopeAsync(); // Disposes the inner scope
+
+			Assert.Equal(1, StaticTestScope9.Current.Value); // Should see the outer scope
+
+			async Task DisposeInnerScopeAsync()
+			{
+				await Task.Yield();
+
+				Assert.Equal(2, StaticTestScope9.Current.Value);
+
+				innerScope.Dispose();
+
+				Assert.Equal(1, StaticTestScope9.Current.Value);
+			}
+		}
+
+		private sealed class StaticTestScope9 : StaticTestScope<StaticTestScope9>
+		{
+			public int Value { get; }
+
+			public StaticTestScope9(int value)
+				: base(AmbientScopeOption.JoinExisting)
+			{
+				this.Value = value;
+
+				this.Activate();
+			}
 		}
 	}
 }

--- a/AmbientContexts.Tests/AmbientScopeTests.State.cs
+++ b/AmbientContexts.Tests/AmbientScopeTests.State.cs
@@ -64,21 +64,6 @@ namespace Architect.AmbientContexts.Tests
 		}
 		
 		[Fact]
-		public void Deactivate_FromActivateState_ShouldResultInNullParents()
-		{
-			using var outerScope = new ManuallyActivatedScope(1, AmbientScopeOption.ForceCreateNew);
-			using var innerScope = new ManuallyActivatedScope(1, AmbientScopeOption.JoinExisting);
-
-			outerScope.Activate();
-			innerScope.Activate();
-			
-			innerScope.Deactivate();
-
-			Assert.Null(innerScope.PhysicalParentScope);
-			Assert.Null(innerScope.EffectiveParentScope);
-		}
-		
-		[Fact]
 		public void Construct_WithActivateFromConstructor_ShouldResultInStateActive()
 		{
 			using var scope = new TestScope(1, AmbientScopeOption.ForceCreateNew);

--- a/AmbientContexts.Tests/AmbientScopeTests.cs
+++ b/AmbientContexts.Tests/AmbientScopeTests.cs
@@ -145,27 +145,6 @@ namespace Architect.AmbientContexts.Tests
 		}
 
 		[Fact]
-		public void Dispose_WithExceptionInSubclassDispose_ShouldStillUnsetParent()
-		{
-			using var scope = new TestScope(1, AmbientScopeOption.JoinExisting)
-			{
-				OnDispose = () => throw new TimeoutException(),
-			};
-
-			try
-			{
-				scope.Dispose();
-			}
-			catch (TimeoutException)
-			{
-				// Ignore our own exception
-			}
-
-			Assert.Null(scope.PhysicalParentScope);
-			Assert.Null(scope.EffectiveParentScope);
-		}
-
-		[Fact]
 		public void PhysicalParentScope_WithNoNesting_ShouldReturnNull()
 		{
 			using var scope = new ManuallyActivatedScope(1, AmbientScopeOption.NoNesting, noNestingIgnoresDefaultScope: true);

--- a/AmbientContexts.Tests/AsyncAmbientScopeTests.cs
+++ b/AmbientContexts.Tests/AsyncAmbientScopeTests.cs
@@ -94,27 +94,6 @@ namespace Architect.AmbientContexts.Tests
 		}
 
 		[Fact]
-		public async Task DisposeAsync_WithExceptionInSubclassDispose_ShouldStillUnsetParent()
-		{
-			using var scope = new TestScope(1, AmbientScopeOption.JoinExisting)
-			{
-				OnDisposeAsync = () => throw new TimeoutException(),
-			};
-
-			try
-			{
-				await scope.DisposeAsync();
-			}
-			catch (TimeoutException)
-			{
-				// Ignore our own exception
-			}
-
-			Assert.Null(scope.PhysicalParentScope);
-			Assert.Null(scope.EffectiveParentScope);
-		}
-
-		[Fact]
 		public Task ConstructAndDispose_WithLifetimeOfTwoParallelUnitTestClasses_ShouldNotInterfereWithEachOther()
 		{
 			var tasks = new ConcurrentQueue<Task>();

--- a/AmbientContexts.Tests/TestScopes.cs
+++ b/AmbientContexts.Tests/TestScopes.cs
@@ -39,7 +39,7 @@ namespace Architect.AmbientContexts.Tests
 		protected override async ValueTask DisposeAsyncImplementation()
 		{
 			var task = this.OnDisposeAsync?.Invoke();
-			if (task != null) await task.Value;
+			if (task is not null) await task.Value;
 		}
 
 		public static TestScope Current => GetAmbientScope();

--- a/AmbientContexts.sln
+++ b/AmbientContexts.sln
@@ -7,7 +7,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AmbientContexts", "AmbientC
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AmbientContexts.Tests", "AmbientContexts.Tests\AmbientContexts.Tests.csproj", "{FCD7E9B1-05A5-43A3-89E6-693AE37D85ED}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AmbientContexts.Example", "AmbientContexts.Example\AmbientContexts.Example.csproj", "{B429D8C3-1510-4626-BD72-2C1E1116D1E5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AmbientContexts.Example", "AmbientContexts.Example\AmbientContexts.Example.csproj", "{B429D8C3-1510-4626-BD72-2C1E1116D1E5}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6FF6409A-7FB5-40C4-A052-78B5BA4E5952}"
+	ProjectSection(SolutionItems) = preProject
+		pipeline-publish-preview.yml = pipeline-publish-preview.yml
+		pipeline-publish-stable.yml = pipeline-publish-stable.yml
+		pipeline-verify.yml = pipeline-verify.yml
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/AmbientContexts/AmbientContexts.csproj
+++ b/AmbientContexts/AmbientContexts.csproj
@@ -36,6 +36,7 @@ Release notes:
 - Improved the protections against race conditions.
 - Parent properties are no longer unset on disposal (although implementations should not rely on this detail).
 - Performance improvement: A scope now avoids even instantiating its AsyncLocal as long as only its default scope is used, as is common in production for certain scopes.
+- Performance improvement: The JIT can now inline more code, since exceptions have been moved into helper methods.
 
 1.1.0:
 - Introduced non-generic AmbientScope base class.

--- a/AmbientContexts/AmbientContexts.csproj
+++ b/AmbientContexts/AmbientContexts.csproj
@@ -10,7 +10,7 @@
     <!-- NoWarn: 1573=SummariesOnOnlySomeParams -->
     <!-- NoWarn: 1591=MissingXmlComments -->
     <NoWarn>1573;1591</NoWarn>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>9</LangVersion>
     <Nullable>Enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
@@ -30,6 +30,12 @@ An example from .NET is System.Transactions.TransactionScope. Any code (such as 
 https://github.com/TheArchitectDev/Architect.AmbientContexts
 
 Release notes:
+
+1.1.1:
+- Manually disposing scopes from a deeper async level (such as a DisposeAsync() method with the async keyword) now properly affects methods up the call stack and no longer breaks scope nesting.
+- Improved the protections against race conditions.
+- Parent properties are no longer unset on disposal (although implementations should not rely on this detail).
+- Performance improvement: A scope now avoids even instantiating its AsyncLocal as long as only its default scope is used, as is common in production for certain scopes.
 
 1.1.0:
 - Introduced non-generic AmbientScope base class.

--- a/AmbientContexts/AmbientContexts.csproj
+++ b/AmbientContexts/AmbientContexts.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.1.1</VersionPrefix>
     <PackageReleaseNotes></PackageReleaseNotes>
     <Description>
 Provides the basis for implementing the Ambient Context pattern. Includes a Clock implementation based on it.

--- a/AmbientContexts/AmbientScope.AsyncLocal.cs
+++ b/AmbientContexts/AmbientScope.AsyncLocal.cs
@@ -100,10 +100,10 @@ namespace Architect.AmbientContexts
 			{
 				var ambientScope = CurrentAmbientScope.Value;
 
-				// A method like DisposeAsync() that disposes an AmbientScope will not propagate that change to its caller
+				// An async method that disposes an AmbientScope, like DisposeAsync(), will not propagate that change to its caller
 				// The caller would see the disposed scope
-				// Navigate up through disposed scopes to counteract this effect
-				// Use the physical rather than the effective parent: ForceCreateNew only obscures until the new scope is disposed
+				// To counteract this effect, navigate up through disposed scopes
+				// Use the physical rather than the effective parent: the scope was disposed, so even if it used ForceCreateNew, its obscurement no longer applies
 				while (ambientScope?.State == AmbientScopeState.Disposed)
 					ambientScope = ambientScope.PhysicalParentScope;
 

--- a/AmbientContexts/AmbientScope.AsyncLocal.cs
+++ b/AmbientContexts/AmbientScope.AsyncLocal.cs
@@ -35,9 +35,11 @@ namespace Architect.AmbientContexts
 			}
 
 			if (ReferenceEquals(newAmbientScope, CurrentAmbientScope.Value))
-				throw new InvalidOperationException("The given scope was already the current ambient scope.");
+				ThrowAlreadyCurrent();
 
 			CurrentAmbientScope.Value = (TConcreteScope)newAmbientScope;
+
+			static void ThrowAlreadyCurrent() => throw new InvalidOperationException("The given scope was already the current ambient scope.");
 		}
 
 		/// <summary>
@@ -52,9 +54,11 @@ namespace Architect.AmbientContexts
 		{
 			var currentAmbientScope = CurrentAmbientScope?.Value;
 
-			if (currentAmbientScope is null) throw new InvalidOperationException("Tried to remove the current ambient scope when there was none.");
+			if (currentAmbientScope is null) ThrowNoAmbientScope();
 
-			RemoveAmbientScope(currentAmbientScope);
+			RemoveAmbientScope(currentAmbientScope!);
+
+			static void ThrowNoAmbientScope() => throw new InvalidOperationException("Tried to remove the current ambient scope when there was none.");
 		}
 
 		/// <summary>
@@ -82,9 +86,11 @@ namespace Architect.AmbientContexts
 		protected static void ReplaceAmbientScope(AmbientScope<TConcreteScope> currentScope, AmbientScope<TConcreteScope>? newAmbientScope)
 		{
 			if (!ReferenceEquals(currentScope, CurrentAmbientScope?.Value))
-				throw new InvalidOperationException("The supposed current scope was not the current ambient scope. Always dispose or deactivate in reverse order of activation.");
+				ThrowNotCurrent();
 
 			SetAmbientScope(newAmbientScope);
+
+			static void ThrowNotCurrent() => throw new InvalidOperationException("The supposed current scope was not the current ambient scope. Always dispose or deactivate in reverse order of activation.");
 		}
 
 		/// <summary>

--- a/AmbientContexts/AmbientScope.cs
+++ b/AmbientContexts/AmbientScope.cs
@@ -50,7 +50,7 @@ namespace Architect.AmbientContexts
 		/// Null otherwise.
 		/// </para>
 		/// <para>
-		/// Note that this property returns null if the scope has not been activated.
+		/// Note that this property always returns null if the scope has not been activated.
 		/// </para>
 		/// </summary>
 		protected TConcreteScope? EffectiveParentScope { get; private set; }
@@ -128,7 +128,7 @@ namespace Architect.AmbientContexts
 		/// </para>
 		/// <para>
 		/// This method should generally be called at the very end of the subclass' constructor.
-		/// <strong>After activation, no constructor may throw, or there is nothing to dispose to undo the activation!</strong>
+		/// <strong>After a scope's constructor activates the scope, it must never throw, or there would be no disposable object to undo the activation!</strong>
 		/// </para>
 		/// </summary>
 		protected void Activate()
@@ -193,7 +193,8 @@ namespace Architect.AmbientContexts
 		/// Returns the effective root scope from the current scope's perspective, which is either itself or the greatest accessible ancestor.
 		/// </para>
 		/// <para>
-		/// An ancestor is accessible if it uses <see cref="AmbientScopeOption.JoinExisting"/>.
+		/// Only a scope that uses <see cref="AmbientScopeOption.JoinExisting"/> can access its predecessor.
+		/// As soon as a scope with another <see cref="AmbientScopeOption"/> is encountered, it termintes the effective chain.
 		/// See also <see cref="EffectiveParentScope"/>.
 		/// </para>
 		/// </summary>

--- a/AmbientContexts/AsyncAmbientScope.cs
+++ b/AmbientContexts/AsyncAmbientScope.cs
@@ -34,42 +34,9 @@ namespace Architect.AmbientContexts
 			// Perform our primary disposal immediately
 			var isDisposing = this.BaseDisposeImplementation();
 
-			if (!isDisposing) return new ValueTask();
-
-			try
-			{
-				// Let the subclass perform its disposal
-				var subclassDisposalTask = this.DisposeAsyncImplementation();
-
-				// On immediate success, finish up
-				if (subclassDisposalTask.IsCompleted)
-				{
-					this.UnsetParent();
-					return subclassDisposalTask;
-				}
-
-				// Return a task that awaits and then finishes up
-				return AwaitTaskAndUnsetParent(subclassDisposalTask);
-			}
-			catch
-			{
-				// On failure, finish up
-				this.UnsetParent();
-				throw;
-			}
-
-			// Local function that awaits the input task and then unsets the parent
-			async ValueTask AwaitTaskAndUnsetParent(ValueTask task)
-			{
-				try
-				{
-					await task;
-				}
-				finally
-				{
-					this.UnsetParent();
-				}
-			}
+			return isDisposing
+				? this.DisposeAsyncImplementation()
+				: new ValueTask();
 		}
 
 		/// <summary>

--- a/AmbientContexts/Time/ClockScope.cs
+++ b/AmbientContexts/Time/ClockScope.cs
@@ -30,7 +30,9 @@ namespace Architect.AmbientContexts
 		/// Returns the currently accessible <see cref="ClockScope"/>.
 		/// The scope is configurable from the outside, such as from startup.
 		/// </summary>
-		internal static ClockScope Current => GetAmbientScope() ?? throw new InvalidOperationException(
+		internal static ClockScope Current => GetAmbientScope() ?? ThrowNotConfigured();
+
+		private static ClockScope ThrowNotConfigured() => throw new InvalidOperationException(
 			$"{nameof(ClockScope)} was not configured. Call {nameof(ClockScopeExtensions)}.{nameof(ClockScopeExtensions.UseClockScope)} on startup.");
 
 		internal DateTime Now => this.NowSource();
@@ -56,7 +58,9 @@ namespace Architect.AmbientContexts
 		private ClockScope(Func<DateTime> nowSource, AmbientScopeOption ambientScopeOption)
 			: base(ambientScopeOption)
 		{
-			this.NowSource = nowSource ?? throw new ArgumentNullException(nameof(nowSource));
+			this.NowSource = nowSource ?? ThrowNullSource();
+
+			static Func<DateTime> ThrowNullSource() => throw new ArgumentNullException(nameof(nowSource));
 		}
 
 		protected override void DisposeImplementation()


### PR DESCRIPTION
1.1.1:
- Manually disposing scopes from a deeper async level (such as a DisposeAsync() method with the async keyword) now properly affects methods up the call stack and no longer breaks scope nesting.
- Improved the protections against race conditions.
- Parent properties are no longer unset on disposal (although implementations should not rely on this detail).
- Performance improvement: A scope now avoids even instantiating its AsyncLocal as long as only its default scope is used, as is common in production for certain scopes.
- Performance improvement: The JIT can now inline more code, since exceptions have been moved into helper methods.